### PR TITLE
Updating required package names for Rocky Linux

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [bdist_rpm]
-requires = python36 python36-libs python36-bottle python36-requests python36-mysql python36-typing
-           python36-psutil python36-dateutil python36-prettytable python36-PyYAML openssl openssh-clients crontabs
+requires = python36 python3-libs python3-bottle python36-requests python3-mysql python3-typing-extensions
+           python36-psutil python3-dateutil python3-prettytable python3-pyyaml openssl openssh-clients crontabs
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [bdist_rpm]
-requires = python36 python3-libs python3-bottle python36-requests python3-mysql python3-typing-extensions
-           python36-psutil python3-dateutil python3-prettytable python3-pyyaml openssl openssh-clients crontabs
+requires = python36 python3-libs python3-bottle python3-requests python3-mysql python3-typing-extensions
+           python3-psutil python3-dateutil python3-prettytable python3-pyyaml openssl openssh-clients crontabs
 


### PR DESCRIPTION
It turns out that some of the required package names have been updated. This PR just brings things up to date. 